### PR TITLE
Clearer jsdomError messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,18 @@ const { JSDOM, VirtualConsole } = require('jsdom');
 
 module.exports = class JSDOMEnvironment {
   constructor(config, options) {
+    const anyConsole = options.console || console;
+    const virtualConsole = new VirtualConsole();
+    virtualConsole.sendTo(anyConsole, { omitJSDOMErrors: true });
+    virtualConsole.on('jsdomError', (error) => {
+      anyConsole.error(error);
+    });
+
     this.dom = new JSDOM('<!DOCTYPE html>', {
       pretendToBeVisual: true,
       runScripts: 'dangerously',
       url: config.testURL,
-      virtualConsole: new VirtualConsole().sendTo(options.console || console),
+      virtualConsole,
       ...config.testEnvironmentOptions,
     });
     const global = (this.global = this.dom.window.document.defaultView);


### PR DESCRIPTION
I encountered a situation where I was creating a 'jsdomError'. Jest reported the error like so:

![Screenshot from 2020-06-26 12-22-20](https://user-images.githubusercontent.com/5783817/85893593-fd945680-b7a7-11ea-8ff7-16551276d73e.png)

At first glance it is easy to miss that the `error.detail` is concatenated to the end of the fourth line, I certainly missed it.

I found that happened because by default [jsdom logs the error.stack and error.default as two parameters to console.error](https://github.com/jsdom/jsdom/blob/master/lib/jsdom/virtual-console.js#L29)

This PR overrides that default and lets jest format the errors, which it does very nicely:

![Screenshot from 2020-06-26 12-28-17](https://user-images.githubusercontent.com/5783817/85893879-8ad7ab00-b7a8-11ea-9796-240e5be5abed.png)

